### PR TITLE
Vberenz/frequency monitoring

### DIFF
--- a/bin/hysr_episode_frequencies
+++ b/bin/hysr_episode_frequencies
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+xterm -e frequency_monitoring -segment_id hysr_episode_frequency &

--- a/bin/hysr_frequencies
+++ b/bin/hysr_frequencies
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+# starting a mujoco instance for the visualization of the simulated robot
+pam_mujoco_visualization simulation visualization &

--- a/bin/hysr_one_ball_swing
+++ b/bin/hysr_one_ball_swing
@@ -30,7 +30,7 @@ def execute(reward_config_path, hysr_config_path):
     swing_posture = [[14000, 22000], [14000, 22000], [17000, 13000], [14000, 16000]]
     pressures = [p for sublist in swing_posture for p in sublist]
 
-    for episode in range(3):
+    for episode in range(5):
         print("EPISODE", episode)
         running = True
         while running:

--- a/bin/hysr_step_frequencies
+++ b/bin/hysr_step_frequencies
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+xterm -e frequency_monitoring -segment_id hysr_step_frequency &

--- a/config/hysr_one_ball_default.json
+++ b/config/hysr_one_ball_default.json
@@ -10,8 +10,10 @@
     },
     "pressure_change_range":18000,
     "trajectory":-1,
-    "accelerated_time":true,
+    "accelerated_time":false,
     "graphics_pseudo_real":false,
-    "graphics_simulation":false,
-    "instant_reset":true
+    "graphics_simulation":true,
+    "instant_reset":true,
+    "frequency_monitoring_episode":true,
+    "frequency_monitoring_step":true
 }

--- a/learning_table_tennis_from_scratch/hysr_one_ball.py
+++ b/learning_table_tennis_from_scratch/hysr_one_ball.py
@@ -352,6 +352,10 @@ class HysrOneBall:
         
     def reset(self):
 
+        # resetting the measure of step frequency monitoring
+        if self._frequency_monitoring_step:
+            self._frequency_monitoring_step.reset()
+        
         # exporting episode frequency
         if self._frequency_monitoring_episode:
             self._frequency_monitoring_episode.ping()

--- a/learning_table_tennis_from_scratch/hysr_one_ball.py
+++ b/learning_table_tennis_from_scratch/hysr_one_ball.py
@@ -1,5 +1,5 @@
 import os,sys,time,math,random,json,site
-import o80,o80_pam,pam_mujoco,context,pam_interface
+import o80,o80_pam,pam_mujoco,context,pam_interface,frequency_monitoring,shared_memory
 import numpy as np
 from pam_mujoco import mirroring
 from . import configure_mujoco
@@ -10,6 +10,8 @@ SEGMENT_ID_GOAL = pam_mujoco.segment_ids.goal
 SEGMENT_ID_HIT_POINT = pam_mujoco.segment_ids.hit_point
 SEGMENT_ID_ROBOT_MIRROR = pam_mujoco.segment_ids.mirroring
 SEGMENT_ID_PSEUDO_REAL_ROBOT = o80_pam.segment_ids.robot
+SEGMENT_ID_EPISODE_FREQUENCY = "hysr_episode_frequency"
+SEGMENT_ID_STEP_FREQUENCY = "hysr_step_frequency"
 
 
 class HysrOneBallConfig:
@@ -17,7 +19,8 @@ class HysrOneBallConfig:
     __slots__ = ("o80_pam_time_step","mujoco_time_step","algo_time_step",
                  "target_position","reference_posture","world_boundaries",
                  "pressure_change_range","trajectory","accelerated_time",
-                 "graphics_pseudo_real","graphics_simulation","instant_reset")
+                 "graphics_pseudo_real","graphics_simulation","instant_reset",
+                 "frequency_monitoring_step","frequency_monitoring_episode")
 
     def __init__(self):
         for s in self.__slots__:
@@ -155,7 +158,24 @@ class HysrOneBall:
         self._target_position = hysr_config.target_position
 
         self._goal = self._simulated_robot_handle.interfaces[SEGMENT_ID_GOAL]
-        
+
+        # if requested, logging info about the frequencies of the steps and/or the
+        # episodes
+        if hysr_config.frequency_monitoring_step:
+            segment_id = hysr_config.frequency_monitoring_step
+            size=1000
+            self._frequency_monitoring_step = frequency_monitoring.FrequencyMonitoring(SEGMENT_ID_STEP_FREQUENCY,
+                                                                                       size)
+        else:
+            self._frequency_monitoring_step = None
+        if hysr_config.frequency_monitoring_episode:
+            segment_id = hysr_config.frequency_monitoring_episode
+            size=1000
+            self._frequency_monitoring_episode = frequency_monitoring.FrequencyMonitoring(SEGMENT_ID_EPISODE_FREQUENCY,
+                                                                                       size)
+        else:
+            self._frequency_monitoring_episode = None
+            
         # if o80_pam (i.e. the pseudo real robot)
         # has been started in accelerated time,
         # the corresponding o80 backend will burst through
@@ -332,6 +352,11 @@ class HysrOneBall:
         
     def reset(self):
 
+        # exporting episode frequency
+        if self._frequency_monitoring_episode:
+            self._frequency_monitoring_episode.ping()
+            self._frequency_monitoring_episode.share()
+        
         # in case the episode was forced to end by the
         # user (see force_episode_over method)
         self._force_episode_over = False
@@ -470,11 +495,17 @@ class HysrOneBall:
         # (reset will set this back to True)
         self._first_episode_step = False
 
-            
+        # exporting step frequency
+        if self._frequency_monitoring_step:
+            self._frequency_monitoring_step.ping()
+            self._frequency_monitoring_step.share()
+           
         # returning
         return observation,reward,episode_over
 
     
     def close(self):
+        shared_memory.clear_shared_memory(SEGMENT_ID_EPISODE_FREQUENCY)
+        shared_memory.clear_shared_memory(SEGMENT_ID_STEP_FREQUENCY)
         pass
 

--- a/readme.md
+++ b/readme.md
@@ -20,17 +20,36 @@ In a first terminal:
 hysr_start_robots
 ```
 
-In a second terminal, optionnaly (for graphics):
+press enter to get the prompt back and optionally:
 
 ```bash
-hysr_visualization
+# display stats regarding frequencies at which
+# steps are running
+hysr_step_frequencies
 ```
 
-and finally:
+and / or:
 
 ```bash
-hysr_one_ball_ppo
+# display stats regarding frequencies at which
+# episodes are running
+hysr_episode_frequencies
 ```
+
+In a *second* terminal, run one of these executables:
+
+- hysr_one_ball_ppo
+- hysr_one_ball_random
+- hysr_one_ball_swing
+- hysr_one_ball_reward_tests
+- hysr_one_ball_reset
+
+The terminal should prompt you to select some configuration file. Modify these configuration based on your needs (see below)
+
+Note:
+- For as long the configuration files are not changed, several executables can be run in sequence without the need to restart ```hysr_start_robot``` (i.e. the same mujoco instances can be reused)
+- For each time a new executable is started, ```hysr_episode_frequencies``` and ```hysr_step_frequencies``` need to be restarted. If the executable did not start correctly, it may be necessary to clean the shared memory (```rm /etc/shm/*```)
+- The preferred way to stop the mujoco simulation is to call: ```pam_mujoco_stop_all``` (in any terminal)
 
 # Configuration files
 

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ setup( name='learning_table_tennis_from_scratch',
                 'bin/hysr_one_ball_reward_tests',
                 "bin/hysr_start_robots",
                 "bin/hysr_visualization",
-                "bin/hysr_episode_frequencies",
-                "bin/hysr_step_frequencies"]
+                "bin/hysr_step_frequencies",
+                "bin/hysr_episode_frequencies"]
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup( name='learning_table_tennis_from_scratch',
        author_email='vberenz@tuebingen.mpg.de',
        license='MIT',
        packages=['learning_table_tennis_from_scratch'],
-       install_requires=['tensorflow==1.15','gym'],
+       #install_requires=['tensorflow==1.15','gym'],
        zip_safe=True,
        data_files=[('learning_table_tennis_from_scratch_config/',
                     ["config/hysr_one_ball_default.json",
@@ -25,7 +25,9 @@ setup( name='learning_table_tennis_from_scratch',
                 'bin/hysr_one_ball_reset',
                 'bin/hysr_one_ball_reward_tests',
                 "bin/hysr_start_robots",
-                "bin/hysr_visualization"]
+                "bin/hysr_visualization",
+                "bin/hysr_episode_frequencies",
+                "bin/hysr_step_frequencies"]
 )
 
 


### PR DESCRIPTION
There are two new executables:
- hysr_episode_frequencies
- hysr_step_frequencies
as well as two corresponding entries in the config file

The executables allow to print in a terminal stats regarding frequencies. See updated readme.

For this to work, it is required:
- to pull treep_isr
- to clone frequency_monitoring (```treep --clone frequency_monitoring```)
- to recompile

Here is the code of frequency monitoring:

https://github.com/intelligent-soft-robots/frequency_monitoring
