### PR TITLE
fix: Remove faulty print

### DIFF
--- a/learning_table_tennis_from_scratch/models.py
+++ b/learning_table_tennis_from_scratch/models.py
@@ -68,10 +68,6 @@ def run_openai_baselines(
     }
     env = make_vec_env(HysrOneBallEnv, env_kwargs=env_config)
 
-    print("models", env)
-    for k, v in dir(env).items():
-        print(k, "\t", v)
-
     ppo_config = OpenAIPPOConfig.from_json(ppo_config_file)
     total_timesteps = ppo_config["num_timesteps"]
     del ppo_config["num_timesteps"]


### PR DESCRIPTION
## Description

`hysr_one_ball_ppo` (and I think other executables as well) were crashing due to this print (`dir()` returns a
list, not a dictionary).

Since it looks like it is just for debugging, I simply removed it now so that I can run the code.   Let me know if it should be kept, then I'll try to fix it.

## How I Tested

By running `hysr_one_ball_ppo`.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
