### PR TITLE
chore: Add basic GitHub Workflows

### DIFF
--- a/.github/workflows/git_fixup.yml
+++ b/.github/workflows/git_fixup.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/.github/workflows/python_black.yml
+++ b/.github/workflows/python_black.yml
@@ -1,0 +1,11 @@
+name: Linters
+
+on: [pull_request]
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable

--- a/.github/workflows/todo_check.yml
+++ b/.github/workflows/todo_check.yml
@@ -1,0 +1,28 @@
+name: TODO checks
+
+on: pull_request
+
+jobs:
+  fixmes:
+    name: New FIXMEs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: git fetch origin ${GITHUB_BASE_REF}
+    - name: Check for FIXMEs
+      uses: luator/github_action_check_new_todos@v1.0.1
+      with:
+          label: FIXME
+          base_ref: origin/${{ github.base_ref }}
+
+  todos:
+    name: New TODOs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: git fetch origin ${GITHUB_BASE_REF}
+    - name: Check for TODOs
+      uses: luator/github_action_check_new_todos@v1.0.1
+      with:
+          label: TODO
+          base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
## Description

Add some basic GitHub Workflows that are automatically executed on pull
requests (copied from trifinger_simulation).  The following checks are
added:

- git.yml: Checks if there are any "fixup!" or "squash!" commits.  To avoid that they are accidentally merged (they should be manually squashed before merging).
- pr_todo_checks.yml: Checks if any "TODO" or "FIXME" comments are added.  The idea is that they should usually be resolved before merging the PR (especially FIXMEs, TODOs might be okay to add, that's why there are separate checks for them).
- lint.yml: Run linters on the code.  For now, only black is used to ensure all code is formatted correctly.  I'd like to add more checks here in the future (e.g. flake8, mypy) but for this, currently existing warnings should first be resolved.

Let me know of what you think about these checks.  These checks are all rather generic, so if you like them, we could add them to all repos.

By default GitHub will only warn about failing checks.  It is possible to mark some as "required", then merging of the PR will be blocked if the check fails.



## How I Tested

They should already run on this pull request, the results should be displayed below the discussion.