### PR TITLE
doc: Use hysr_stop instead of pam_mujoco_stop_all

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ a row without restarting the robots. If the configuration is changed, then the r
 In any terminal, type:
 
 ```
-pam_mujoco_stop_all
+hysr_stop
 ```
 
 ## Extra executables


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Use `hysr_stop` in the README instead of `pam_mujoco_stop_all`.
`hysr_stop` calls `pam_mujoco_stop_all` internally but also kills
`hysr_visualization` which would otherwise proceed to run in the
background.



## How I Tested

```
hysr_start_robots
hysr_one_ball_swing
hysr_stop
```