### PR TITLE
Add example configuration

### DIFF
--- a/config/hysr_demos.json
+++ b/config/hysr_demos.json
@@ -4,12 +4,16 @@
     "mujoco_time_step":0.002,
     "algo_time_step":0.01,
     "pam_config_file":"/opt/mpi-is/pam_interface/pam_sim.json",
-    "robot_position":[0.5, 0.0, -0.44],
+    "robot_position":[0.435, 0.1175, -0.0],
+    "robot_orientation":"-1 0 0 0 -1 0",
+    "table_position":[0.8, 1.7, -0.475],
+    "table_orientation":"-1 0 0 0 -1 0",
+    "starting_pressures":[[18000,18000],[18000,18000],[18000,18000],[18000,18000]],
     "target_position":[0.45,2.7,-0.45],
     "reference_posture":[[19900,16000],[16800,19100],[18700,17300],[18000,18000]],
     "world_boundaries":{
-	"min":[0.0,-1.0,0.17],
-	"max":[1.6,3.5,1.5]
+        "min":[0.0,-1.0,0.17],
+        "max":[1.6,3.5,1.5]
     },
     "pressure_change_range":18000,
     "trajectory":-1,

--- a/config/hysr_demos.json
+++ b/config/hysr_demos.json
@@ -29,6 +29,6 @@
     "xterms":false,
     "frequency_monitoring_episode":true,
     "frequency_monitoring_step":true,
-    "robot_integrity_check":"/tmp/hysr_robot_integrity",
+    "robot_integrity_check":false,
     "robot_integrity_threshold":0.6
 }

--- a/config/openai_ppo_default.json
+++ b/config/openai_ppo_default.json
@@ -14,7 +14,7 @@
     "num_hidden":512,
     "activation":"tf.tanh",
     "nsteps": 4096,
-    "load_path": "/tmp/model",
+    "load_path": null,
     "save_path": "/tmp/model",
     "log_interval":1,
     "save_interval":1

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,10 @@
+Example Configuration
+=====================
+
+This directory contains an example configuration `config.json`.  It can be used
+to run the code in simulation:
+
+    $ cd learning_table_tennis_from_scratch/example
+    $ hysr_start_robots    # Start the simulation backend
+    $ hysr_one_ball_swing  # Run something on the robot
+    $ hysr_stop            # Stop all backend processes

--- a/example/config.json
+++ b/example/config.json
@@ -1,0 +1,7 @@
+{
+    "reward_config": "../config/reward_default.json",
+    "hysr_config": "../config/hysr_demos.json",
+    "pam_config": "/opt/mpi-is/pam_models/hill.json",
+    "ppo_config": "../config/openai_ppo_default.json",
+    "ppo_common_config": "../config/ppo_common_default.json"
+}

--- a/readme.md
+++ b/readme.md
@@ -191,6 +191,12 @@ In any terminal, type:
 hysr_stop
 ```
 
+## Example configuration
+
+The `example/` directory contains an example configuration that can be used to
+run the above commands.  See the README there for more information.
+
+
 ## Extra executables
 
 The following executables can be started after the robot:


### PR DESCRIPTION
## Description
Add a `example` directory that contains a demo config file which can be used to run the code in simulation.

This is what I am currently using for testing.  I think it is good for newcomers to have an example setup that can just be run without further background knowledge I propose to add it to the repository.

While with this configuration I can run the code without error, the robot doesn't move a lot, so I am actually not sure if the specific configuration makes sense.  Please let me know if I should change something.


## How I Tested

By running it as described in the README.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
