### PR TITLE
Update hysr_on_ball_default_sim.json

### DIFF
--- a/config/hysr_one_ball_default_sim.json
+++ b/config/hysr_one_ball_default_sim.json
@@ -1,13 +1,18 @@
 {
+    "real_robot": false,
     "o80_pam_time_step":0.002,
     "mujoco_time_step":0.002,
     "algo_time_step":0.01,
     "robot_position":[0.435, 0.1175, -0.0],
+    "robot_orientation":"-1 0 0 0 -1 0",
+    "table_position":[0.8, 1.7, -0.475],
+    "table_orientation":"-1 0 0 0 -1 0",
+    "starting_pressures":[[18000,18000],[18000,18000],[18000,18000],[18000,18000]],
     "target_position":[0.45,2.7,-0.45],
     "reference_posture":[[15000,15000],[15000,15800],[15000,15000],[15000,15000]],
     "world_boundaries":{
-	"min":[0.0,-1.0,0.17],
-	"max":[1.6,3.5,1.5]
+        "min":[0.0,-1.0,0.17],
+        "max":[1.6,3.5,1.5]
     },
     "pam_config_file":"/home/sguist/Software/ISR/workspace/src/pam_interface/config/pam_sim.json",
     "pressure_change_range":1800,

--- a/config/hysr_one_ball_default_sim.json
+++ b/config/hysr_one_ball_default_sim.json
@@ -14,7 +14,7 @@
         "min":[0.0,-1.0,0.17],
         "max":[1.6,3.5,1.5]
     },
-    "pam_config_file":"/home/sguist/Software/ISR/workspace/src/pam_interface/config/pam_sim.json",
+    "pam_config_file":"/opt/mpi-is/pam_interface/pam_sim.json",
     "pressure_change_range":1800,
     "trajectory":-1,
     "accelerated_time":true,


### PR DESCRIPTION
## Description

- Add new parameters (values copied from `hysr_demos.json`).
- Use `pam_sim.json` from `/opt/mpi-is` instead of the custom path.


## How I Tested

Use it in `example/config.json` to run `hysr_one_ball_ppo`.

Note that there is currently an unresolved issue that makes the training hang.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
