### PR TITLE
Optional argument for config file

### DIFF
--- a/bin/hysr_one_ball_ppo
+++ b/bin/hysr_one_ball_ppo
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
-import os
+import argparse
 import json
+import os
+import pathlib
+
 from learning_table_tennis_from_scratch.models import run_stable_baselines
 from learning_table_tennis_from_scratch.models import run_openai_baselines
 from learning_table_tennis_from_scratch.jsonconfig import get_json_config
@@ -54,21 +57,33 @@ def _execute(
         )
 
 
-def _configure():
+def _configure(config_file):
     files = get_json_config(
         expected_keys=[
             "reward_config",
             "hysr_config",
             "ppo_config",
             "ppo_common_config",
-        ]
+        ],
+        config_file=config_file,
     )
 
     return files
 
 
 def _run():
-    config = _configure()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "config",
+        type=pathlib.Path,
+        nargs="?",  # this is optional
+        help="""Optional path to config JSON file.  If not set, the file is
+            searched for in the current working directory.
+        """,
+    )
+    args = parser.parse_args()
+
+    config = _configure(args.config)
     if config is None:
         return
     _execute(

--- a/bin/hysr_start_robots
+++ b/bin/hysr_start_robots
@@ -1,42 +1,60 @@
 #! /bin/bash
 
-# this executable starts all instances of pam_mujoco.
-# it configures itself based on the json file that should be
-# present in the current directory. This json file should
-# have an entry "hysr_config", pointing to a json file. This json
-# file should have the entries:
+# This executable starts all instances of pam_mujoco.
+#
+# It can can be called either with the path to a JSON config file as argument or
+# without arguments, in which case it searches for a JSON file in the current
+# working directory.
+# This JSON file should have an entry "hysr_config", pointing to an other JSON
+# file. This other JSON file should have the entries:
 # extra_balls_set : indication if an instance of pam_mujoco for
 #                   extra balls should be started
 # graphics : indication if an instance pam_mujoco with graphics
 #            should be started
 # xterms: indication if the instances of pam_mujoco should be
 #         started in the current terminal, or in separated terminals
-
-# typically, hysr_start_robots will be started in a folder,
+#
+# Typically, hysr_start_robots will be started in a folder,
 # then a "hysr executable" (e.g. hysr_one_ball_ppo) will be started
 # from the same folder, so both use the same config files.
 
 
-# list json files in current directory
-json_files=( $(ls *.json) )
+if [ $# == 0 ]; then
+    # list json files in current directory
+    json_files=( $(ls *.json) )
 
-# exiting if no json file
-if [ ! $? -eq 0 ]; then
-    >&2 echo "failed to find a json file in the current directory"
+    # exiting if no json file
+    if [ ! $? -eq 0 ]; then
+        >&2 echo "failed to find a json file in the current directory"
+        exit 1
+    fi
+
+    nb_json_files=${#json_files[@]}
+
+    # exiting if more than 1 json file
+    if [ ! $nb_json_files -eq 1 ]; then
+        >&2 echo "failed more than one json file in the current directory"
+        >&2 echo "${json_files[@]}"
+        exit 1
+    fi
+
+    # only 1 json file, going forward
+    json_file=$(ls *.json)
+
+elif [ $# == 1 ]; then
+    json_file="$1"
+    if [ ! -e "${json_file}" ]
+    then
+        >&2 echo "given config file '${json_file}' does not exist."
+        exit 1
+    fi
+else
+    >&2 echo "ERROR: Invalid number of arguments."
+    >&2 echo "Usage:\t $0 [<config_file>]"
     exit 1
 fi
+echo "Use config file ${json_file}"
 
-nb_json_files=${#json_files[@]}
-
-# exiting if more than 1 json file
-if [ ! $nb_json_files -eq 1 ]; then
-    >&2 echo "failed more than one json file in the current directory"
-    >&2 echo "${json_files}"
-    exit 1
-fi
-    
-# only 1 json file, going forward
-json_file=$(ls *.json)
 
 # reading the "hysr_config" entry from it
 hysr_config=$(jq -r .hysr_config ${json_file})


### PR DESCRIPTION
## Description

Add option to explicitly specify the path to the JSON config file in `hysr_start_robots` and `hysr_one_ball_ppo`.
This makes the setup for the hyperparameter optimisation easier, as it can be run in a directory with other (unrelated) JSON files.

The default behaviour (i.e. when no argument is given) is still to search in the cwd like before.


## How I Tested

By manually running the scripts.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
