### PR TITLE
Add parameter for random seed

### DIFF
--- a/bin/hysr_one_ball_ppo
+++ b/bin/hysr_one_ball_ppo
@@ -4,6 +4,8 @@ import argparse
 import json
 import os
 import pathlib
+import random
+import time
 
 from learning_table_tennis_from_scratch.models import run_stable_baselines
 from learning_table_tennis_from_scratch.models import run_openai_baselines
@@ -24,7 +26,12 @@ def _read_ppo_common_config(jsonpath):
             "failed to parse reward json configuration file {}: {}".format(jsonpath, e)
         )
 
-    expected_keys = ("use_openai_baselines", "log_episodes", "log_tensorboard")
+    expected_keys = (
+        "use_openai_baselines",
+        "log_episodes",
+        "log_tensorboard",
+        "random_seed",
+    )
 
     for key in expected_keys:
         if key not in conf.keys():
@@ -39,6 +46,16 @@ def _execute(
 
     common_conf = _read_ppo_common_config(ppo_common_config_file)
 
+    seed = common_conf["random_seed"]
+    if not seed:
+        # If no explicit seed is given, generate one based on the current time.
+        # Take the first 9 positions after the decimal point.  By discarding
+        # the integer part (`x % 1`), it is ensured that the resulting number
+        # does not get too big (limit for the seed is 2**32 - 1).
+        seed = int((time.time() % 1) * 1e9)
+    print("Use random seed %d" % seed)
+
+    random.seed(seed)
     if common_conf["use_openai_baselines"]:
         run_openai_baselines(
             reward_config_file,
@@ -46,6 +63,7 @@ def _execute(
             ppo_config_file,
             common_conf["log_episodes"],
             common_conf["log_tensorboard"],
+            seed=seed,
         )
     else:
         run_stable_baselines(

--- a/config/ppo_common_default.json
+++ b/config/ppo_common_default.json
@@ -1,5 +1,6 @@
 {
-    "use_openai_baselines":true,
-    "log_episodes":false,
-    "log_tensorboard":true
+    "use_openai_baselines": true,
+    "log_episodes": false,
+    "log_tensorboard": true,
+    "random_seed": null
 }

--- a/learning_table_tennis_from_scratch/models.py
+++ b/learning_table_tennis_from_scratch/models.py
@@ -9,6 +9,7 @@ def run_stable_baselines(
     ppo_config_file,
     log_episodes=False,
     log_tensorboard=False,
+    seed=None,
 ):
 
     from stable_baselines.common.policies import MlpPolicy
@@ -26,7 +27,12 @@ def run_stable_baselines(
     ppo_config = PPOConfig.from_json(ppo_config_file)
     if log_tensorboard:
         model = PPO2(
-            MlpPolicy, env, verbose=1, log_tensorboard=log_tensorboard, **ppo_config
+            MlpPolicy,
+            env,
+            verbose=1,
+            log_tensorboard=log_tensorboard,
+            seed=seed,
+            **ppo_config
         )
     else:
         model = PPO2(MlpPolicy, env, verbose=1, **ppo_config)
@@ -41,6 +47,7 @@ def run_openai_baselines(
     log_episodes=False,
     log_tensorboard=False,
     model_file_path=None,
+    seed=None,
 ):
     import tensorflow as tf
     from stable_baselines.common import make_vec_env
@@ -65,25 +72,14 @@ def run_openai_baselines(
     alg = "ppo2"
     learn = get_alg_module_openai_baselines(alg).learn
 
-    # seed = 123
     if model_file_path is None:
         print("total timesteps:", total_timesteps)
-        model = learn(
-            env=env,
-            # seed=seed,
-            total_timesteps=total_timesteps,
-            **ppo_config
-        )
+        model = learn(env=env, seed=seed, total_timesteps=total_timesteps, **ppo_config)
         model.save("ppo2_openai_baselines_hysr_one_ball")
 
     else:
         ppo_config["load_path"] = model_file_path
-        model = learn(
-            env=env,
-            # seed=seed,
-            total_timesteps=0,
-            **ppo_config
-        )
+        model = learn(env=env, seed=seed, total_timesteps=0, **ppo_config)
 
     if save_path:
         model.save(save_path)


### PR DESCRIPTION
## Description

Add parameter "random_seed" to ppo_common_config to specify a random seed.

If set to "null" the current time is used as seed (and printed to stdout), so even when not specifying a fixed seed, we always use a known seed (so runs can be reproduced).
The idea is that you can normally leave it "null" but if you want to reproduce a training run (e.g. for debugging), you can get the seed from the output of that run and set it in the config.

## How I Tested

Started the training to verify there is no error.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
