### PR TITLE
Hyperparameter Search: Run learning multiple times for each configuration

### DIFF
--- a/hp_optim/README.md
+++ b/hp_optim/README.md
@@ -127,3 +127,33 @@ E.g. to overwrite the parameters "num_hidden" in the config file that is given
 for "ppo_config" in the template file (see above), the name would be
 
     config.ppo_config.num_hidden
+
+
+### Configuring number of reruns and retries
+
+Independent of the `with_restarts` option of cluster utils, the
+`run_learning.py` script provides the option to rerun the learning multiple
+times in each job.  The metric for the optimisation is then the mean reward of
+these runs, thus reducing the variance.
+This can be configured in the configuration file by specifying
+`learning_runs_per_job` in the `fixed_params` section:
+
+    "fixed_params": {
+        "learning_runs_per_job": 2
+    }
+
+The default is 3.
+
+Further failed jobs can be retried for a configurable number of times.  This can
+be useful for failure cases that only happen sometimes (e.g. based on the random
+seed) so that there is a high chance that the run will be successful when simply
+trying again with the same settings.
+This can be configured in the configuration file by specifying
+`max_attempts` in the `fixed_params` section:
+
+    "fixed_params": {
+        "max_attempts": 2
+    }
+
+Set to 1 for a single attempt without retries.  The default is 3.
+

--- a/hp_optim/hp_optim_ppo.json
+++ b/hp_optim/hp_optim_ppo.json
@@ -19,6 +19,8 @@
         "bid": 10
     },
     "fixed_params": {
+        "learning_runs_per_job": 3,
+        "max_attempts": 2,
         "config.config_templates": "./hp_optim/config_templates_ppo.json",
         "singularity.image": "~/learning_table_tennis_from_scratch.sif",
         "singularity.script": "./hp_optim/run_learning.py"

--- a/hp_optim/run_learning.py
+++ b/hp_optim/run_learning.py
@@ -16,8 +16,15 @@ import sys
 import time
 import typing
 
+import numpy as np
 import cluster
 import smart_settings.param_classes
+
+
+# Max. number of attempts.  If it fails this many times, do not try again.
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_LEARNING_RUNS_PER_JOB = 3
+RESTART_INFO_FILENAME = "restarts.json"
 
 
 def prepare_config_file(
@@ -118,7 +125,7 @@ def setup_config(working_dir: pathlib.Path, params: dict) -> pathlib.Path:
     return main_config_file
 
 
-def read_reward_from_log(log_dir: pathlib.PurePath):
+def read_reward_from_log(log_dir: pathlib.PurePath) -> float:
     """Extract 'eprewmean' from the log.
 
     Args:
@@ -141,15 +148,75 @@ def read_reward_from_log(log_dir: pathlib.PurePath):
     return eprewmean
 
 
+# TODO maybe better to implement this in a class
+def run_learning(config_file, env, proc_backend):  # TODO type hints
+    print("\n\n#### Start learning\n", flush=True)
+    start = time.time()
+    proc_learning = subprocess.Popen(
+        ["hysr_one_ball_ppo", os.fspath(config_file)], env=env
+    )
+
+    # monitor processes
+    while True:
+        time.sleep(5)
+
+        if proc_backend.poll() is not None:
+            # backend terminated, this is bad!
+            # kill learning and fail
+            proc_learning.kill()
+            raise subprocess.CalledProcessError(
+                proc_backend.returncode, proc_backend.args
+            )
+
+        if proc_learning.poll() is not None:
+            if proc_learning.returncode == 0:
+                break
+            else:
+                raise subprocess.CalledProcessError(
+                    proc_learning.returncode, proc_learning.args
+                )
+                # there is no need to explicitly terminate the backend
+                # here, this is done by hysr_stop below
+
+    duration = (time.time() - start) / 60
+    print("\n\nlearning took %0.2f min" % duration, flush=True)
+
+    # extract eprewmean from the log
+    log_dir = pathlib.Path(env["OPENAI_LOGDIR"])
+    eprewmean = read_reward_from_log(log_dir)
+    print("Final Reward:", eprewmean, flush=True)
+
+    return eprewmean
+
+
 def main():
     # get parameters (make mutable so defaults can easily be set later)
     params = cluster.read_params_from_cmdline(make_immutable=False)
+    working_dir = pathlib.Path(params.working_dir)
+
+    # Overwrite some values from the config templates to disable any graphical
+    # interfaces and to save the model in working_dir (unless a different value
+    # is already explicitly set in params).
+    default_params = {
+        "config": {
+            "hysr_config": {
+                "graphics": False,
+                "xterms": False,
+            },
+            "ppo_config": {
+                "save_path": os.fspath(working_dir / "model"),
+            },
+        },
+        "learning_runs_per_job": DEFAULT_LEARNING_RUNS_PER_JOB,
+        "max_attempts": DEFAULT_MAX_ATTEMPTS,
+    }
+    params = smart_settings.param_classes.update_recursive(
+        params, default_params, overwrite=False
+    )
 
     print("Params:")
     print(params)
-    print("---")
-
-    working_dir = pathlib.Path(params.working_dir)
+    print("-------------")
 
     # prepare environment
     env = dict(
@@ -158,114 +225,93 @@ def main():
         OPENAI_LOGDIR=os.fspath(working_dir / "training_logs"),
     )
 
-    # Overwrite some values from the config templates to disable any graphical
-    # interfaces and to save the model in working_dir (unless a different value
-    # is already explicitly set in params).
-    default_params = {
-        "hysr_config": {
-            "graphics": False,
-            "xterms": False,
-        },
-        "ppo_config": {
-            "save_path": os.fspath(working_dir / "model"),
-        },
-    }
-    params.config = smart_settings.param_classes.update_recursive(
-        params.config, default_params, overwrite=False
-    )
-
     config_file = setup_config(working_dir, params.config)
     os.chdir(working_dir)
 
-    try:
-        print("Start robots")
-        proc_backend = subprocess.Popen(["hysr_start_robots", os.fspath(config_file)])
+    restart_info_path = working_dir / RESTART_INFO_FILENAME
+    if restart_info_path.exists():
+        with open(restart_info_path, "r") as f:
+            restart_info = json.load(f)
+    else:
+        restart_info = {
+            "finished_runs": 0,
+            "eprewmean": [],
+            "failed_runs": [0] * params.learning_runs_per_job,
+        }
 
-        print("Start learning")
-        start = time.time()
-        proc_learning = subprocess.Popen(
-            ["hysr_one_ball_ppo", os.fspath(config_file)], env=env
+    run_number = restart_info["finished_runs"]
+    failed_runs = restart_info["failed_runs"][run_number]
+    run_id = f"{run_number}-{failed_runs}"
+
+    try:
+        print(
+            f"\n\n############################# Start Run {run_id}\n",
+            flush=True,
         )
 
-        # monitor processes
-        while True:
-            time.sleep(5)
+        print("#### Start robots\n", flush=True)
+        proc_backend = subprocess.Popen(["hysr_start_robots", os.fspath(config_file)])
 
-            if proc_backend.poll() is not None:
-                # backend terminated, this is bad!
-                # kill learning and fail
-                proc_learning.kill()
-                raise subprocess.CalledProcessError(
-                    proc_backend.returncode, proc_backend.args
-                )
+        eprewmean = run_learning(config_file, env, proc_backend)
 
-            if proc_learning.poll() is not None:
-                if proc_learning.returncode == 0:
-                    break
-                else:
-                    raise subprocess.CalledProcessError(
-                        proc_learning.returncode, proc_learning.args
-                    )
-                    # there is no need to explicitly terminate the backend
-                    # here, this is done by hysr_stop below
-
-        duration = (time.time() - start) / 60
-        print("\n\nlearning took %0.2f min" % duration)
+        restart_info["finished_runs"] += 1
+        restart_info["eprewmean"].append(eprewmean)
 
     except subprocess.CalledProcessError as e:
-        # In case of any failure, restart with the same parameters (using
-        # cluster.exit_for_resume()).
-
-        # Max. number of attempts.  If it fails this many times, do not try
-        # again.
-        # TODO: Make this configurable?
-        MAX_ATTEMPTS = 3
-
-        print("\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+        print("\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
         print("RUN FAILED! (%s terminated with exit code %d)" % (e.cmd, e.returncode))
 
-        # NOTE: Do not use ".json" extension for the file to not mess with the
-        # automatic detection of "config.json" by the hysr scripts.
-        restart_log_file = working_dir / "restarts.log"
-        failed_runs = 0
-        if restart_log_file.exists():
-            with open(restart_log_file, "r") as f:
-                restart_log = json.load(f)
-                failed_runs = restart_log["failed_runs"]
-
         failed_runs += 1
-        with open(restart_log_file, "w") as f:
-            json.dump({"failed_runs": failed_runs}, f)
-
-        if failed_runs >= MAX_ATTEMPTS:
-            print("Maximum number of restarts is reached.  Exit with failure.")
-            return 1
-        else:
-            print("Exit for restart.")
-
-            # move training log files to separate directory to avoid confusion
-            training_log_dir = pathlib.Path(env["OPENAI_LOGDIR"])
-            if training_log_dir.exists():
-                new_trainig_log_dir = env["OPENAI_LOGDIR"] + "_failed_{}".format(
-                    failed_runs
-                )
-                training_log_dir.rename(new_trainig_log_dir)
-
-            # we don't really plan to resume but restart from scratch but it
-            # shouldn't make a difference for cluster_utils
-            cluster.exit_for_resume()
+        restart_info["failed_runs"][run_number] = failed_runs
 
     finally:
-        print("We are done, shut down.")
+        print("Stop backend [hysr_stop]")
         subprocess.run(["hysr_stop"])
 
-    # extract eprewmean from the log
-    log_dir = pathlib.Path(env["OPENAI_LOGDIR"])
-    eprewmean = read_reward_from_log(log_dir)
-    print("Final Reward:", float(eprewmean))
+    # rename training log directory, so it does not get overwritten by next run
+    training_log_dir = pathlib.Path(env["OPENAI_LOGDIR"])
+    if training_log_dir.exists():
+        new_trainig_log_dir = env["OPENAI_LOGDIR"] + "_" + run_id
+        training_log_dir.rename(new_trainig_log_dir)
+
+    # store the restart log
+    with open(restart_info_path, "w") as f:
+        json.dump(restart_info, f)
+
+    # if it failed too often, abort with error
+    if failed_runs >= params.max_attempts:
+        raise RuntimeError("Maximum number of retries is reached.  Exit with failure.")
+
+    # if desired number of runs have not yet finished, exit for resume (i.e. restart
+    # with a new cluster job)
+    if restart_info["finished_runs"] < params.learning_runs_per_job:
+        # print separator to both stdout and stderr
+        print(
+            f"Exit for restart [{run_id}].\n"
+            "==========================================\n\n"
+        )
+        print(
+            f"Exit for restart [{run_id}].\n"
+            "==========================================\n\n",
+            file=sys.stderr,
+        )
+
+        fraction_finished = restart_info["finished_runs"] / params.learning_runs_per_job
+        cluster.announce_fraction_finished(fraction_finished)
+        cluster.exit_for_resume()
+
+    # if this line is reached, all N runs have finished --> save the results
 
     # save the reward for cluster utils
-    metrics = {"eprewmean": eprewmean}
+    metrics = {
+        "mean_eprewmean": np.mean(restart_info["eprewmean"]),
+        "std_eprewmean": np.std(restart_info["eprewmean"]),
+    }
+    print(
+        "Result of {} runs: {mean_eprewmean:.4f} (std: {std_eprewmean:.4f})".format(
+            params.learning_runs_per_job, **metrics
+        )
+    )
     cluster.save_metrics_params(metrics, params)
 
     return 0

--- a/hp_optim/run_learning.py
+++ b/hp_optim/run_learning.py
@@ -149,7 +149,26 @@ def read_reward_from_log(log_dir: pathlib.PurePath) -> float:
 
 
 # TODO maybe better to implement this in a class
-def run_learning(config_file, env, proc_backend):  # TODO type hints
+def run_learning(
+    config_file: typing.Union[str, os.PathLike],
+    env: typing.Dict[str, str],
+    proc_backend: subprocess.Popen,
+) -> float:
+    """Start the learning and monitor processes.
+
+    Args:
+        config_file: Path to the config file for hysr_one_ball_ppo.
+        env: Dictionary with environment variables used to set up the environment of the
+            learning process.
+        proc_backend: The already started backend process (hysr_start_robots).  Used to
+            monitor for failures.
+
+    Returns:
+        The score of the learning (eprewmean).
+
+    Raises:
+        subprocess.CalledProcessError: if one of the processes fails.
+    """
     print("\n\n#### Start learning\n", flush=True)
     start = time.time()
     proc_learning = subprocess.Popen(
@@ -189,7 +208,7 @@ def run_learning(config_file, env, proc_backend):  # TODO type hints
     return eprewmean
 
 
-def main():
+def main() -> int:
     # get parameters (make mutable so defaults can easily be set later)
     params = cluster.read_params_from_cmdline(make_immutable=False)
     working_dir = pathlib.Path(params.working_dir)

--- a/hp_optim/run_singularity.py
+++ b/hp_optim/run_singularity.py
@@ -91,9 +91,12 @@ def main():
     # locally
     stdout_file = working_dir / "stdout.txt"
     stderr_file = working_dir / "stderr.txt"
-    with open(stdout_file, "wb") as f_out, open(stderr_file, "wb") as f_err:
-        subprocess.run(cmd, check=True, stdout=f_out, stderr=f_err)
+    with open(stdout_file, "ab") as f_out, open(stderr_file, "ab") as f_err:
+        result = subprocess.run(cmd, stdout=f_out, stderr=f_err)
+
+    # forward the return code
+    return result.returncode
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/learning_table_tennis_from_scratch/models.py
+++ b/learning_table_tennis_from_scratch/models.py
@@ -49,7 +49,12 @@ def run_openai_baselines(
     model_file_path=None,
     seed=None,
 ):
+    import warnings
+    warnings.filterwarnings("ignore", message=r"Passing", category=FutureWarning)
+
     import tensorflow as tf
+    tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
+
     from stable_baselines.common import make_vec_env
 
     env_config = {


### PR DESCRIPTION
## Description

To reduce the noise in the estimated reward for a given configuration, run the learning multiple times in each job and use mean reward as metric for the optimisation.

This is implemented using `cluster.exit_for_resume()`, i.e. for each iteration of learning the cluster job is restarted.  This way the
duration of the single cluster jobs does not increase and it also makes it easier to handle the restarts in case of failure more properly. The "restarts" log file is extended for this to not only include the number of failed runs but also the rewards of the finished runs and a "finished runs" counter.

Further changes:

- Use ".json" for restarts log. Since the config file is explicitly
  passed to the hysr scripts now, there is no reason to not use ".json"
  here.
- Make the max. number of retries in case of failures configurable.
- Disable warnings caused by tensorflow (to reduce the noise in the stderr output)

I'm planning to refactor the run_learning.py script but thought it might be good to already merge the current state, so the feature can already be used.

**Note:** `cluster.exit_for_resume()` seems not to work when running locally (i.e. not on the cluster), so unfortunately it is not possible to test this locally anymore unless that issue gets fixed.

## How I Tested

By running it on the cluster with very short training duration.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
