### PR TITLE
Move RestartInfo to utils module and fix bug

### DIFF
--- a/hp_optim/run_learning.py
+++ b/hp_optim/run_learning.py
@@ -21,6 +21,8 @@ import numpy as np
 import cluster
 import smart_settings.param_classes
 
+from utils import RestartInfo
+
 
 # Max. number of attempts.  If it fails this many times, do not try again.
 DEFAULT_MAX_ATTEMPTS = 3
@@ -329,74 +331,6 @@ class Runner:
         logger.info("Final Reward: %0.2f" % eprewmean)
 
         return eprewmean
-
-
-class RestartInfo:
-    """Provides access to the restart info.
-
-    The "restart info" contains information about the number of already finished
-    training runs as well as failed attempts of the current job.
-    """
-
-    def __init__(self, file_path: typing.Union[str, os.PathLike]):
-        """
-        Args:
-            file_path: Path to the file in which the restart info is stored.
-        """
-        self._file_path = pathlib.Path(file_path)
-
-        # load
-        if self._file_path.exists():
-            with open(self._file_path, "r") as f:
-                self._data = json.load(f)
-        else:
-            self._data = {"finished_runs": 0, "eprewmean": [], "failed_attempts": {}}
-
-    def save(self):
-        """Save changes to file.
-
-        Call this to save changes on the restart info to the file.
-        """
-        with open(self._file_path, "w") as f:
-            json.dump(self._data, f)
-
-    @property
-    def finished_runs(self) -> int:
-        """Get number of already finished runs.
-
-        This also corresponds to the index of the current run (starting at zero).
-        """
-        return self._data["finished_runs"]
-
-    @property
-    def failed_attempts(self) -> int:
-        """Get number of failed attempts for the current run."""
-        try:
-            return self._data["failed_attempts"][self.finished_runs]
-        except KeyError:
-            self._data["failed_attempts"][self.finished_runs] = 0
-            return 0
-
-    @property
-    def rewards(self) -> typing.List[float]:
-        """Get list of rewards of all runs."""
-        return self._data["eprewmean"]
-
-    def mark_run_finished(self, eprewmean: float):
-        """Mark the current run as successfully finished and log its reward.
-
-        Args:
-            eprewmean: Reward that was achieved by the run.
-        """
-        self._data["finished_runs"] += 1
-        self._data["eprewmean"].append(eprewmean)
-
-    def mark_attempt_failed(self):
-        """Mark the current attempt as failed."""
-        try:
-            self._data["failed_attempts"][self.finished_runs] += 1
-        except KeyError:
-            self._data["failed_attempts"][self.finished_runs] = 1
 
 
 def main() -> int:

--- a/hp_optim/tests/test_utils.py
+++ b/hp_optim/tests/test_utils.py
@@ -1,0 +1,72 @@
+import pytest
+
+from utils import RestartInfo
+
+
+@pytest.fixture
+def restart_info(tmp_path):
+    return RestartInfo(tmp_path / "restartinfo.json")
+
+
+def test_restartinfo_init(restart_info):
+    """Test if a new RestartInfo instance is initialised correctly."""
+    assert restart_info.finished_runs == 0
+    assert restart_info.failed_attempts == 0
+    assert restart_info.rewards == []
+
+
+def test_restartinfo_finish(restart_info):
+    """Test if adding finished runs works correctly."""
+    restart_info.mark_run_finished(42)
+    assert restart_info.finished_runs == 1
+    assert restart_info.failed_attempts == 0
+    assert restart_info.rewards == [42]
+
+    restart_info.mark_run_finished(13)
+    assert restart_info.finished_runs == 2
+    assert restart_info.failed_attempts == 0
+    assert restart_info.rewards == [42, 13]
+
+
+def test_restartinfo_failed(restart_info):
+    """Test if marking runs as failed increases the counter correctly."""
+    restart_info.mark_attempt_failed()
+    assert restart_info.finished_runs == 0
+    assert restart_info.failed_attempts == 1
+
+    restart_info.mark_attempt_failed()
+    assert restart_info.finished_runs == 0
+    assert restart_info.failed_attempts == 2
+
+    # marking finished should reset the failed attempts counter
+    restart_info.mark_run_finished(42)
+    assert restart_info.finished_runs == 1
+    assert restart_info.failed_attempts == 0
+
+    restart_info.mark_attempt_failed()
+    assert restart_info.finished_runs == 1
+    assert restart_info.failed_attempts == 1
+
+
+def test_restartinfo_finish_save(restart_info):
+    """Test if saving and reloading works with some finished runs."""
+    restart_info.mark_run_finished(42)
+    restart_info.mark_run_finished(13)
+    restart_info.save()
+
+    # load new instance from the saved file
+    rs2 = RestartInfo(restart_info.file_path)
+    assert restart_info._data == rs2._data
+
+
+def test_restartinfo_failed_save(restart_info):
+    """Test if saving and reloading works with some failed attempts."""
+    restart_info.mark_attempt_failed()
+    restart_info.mark_attempt_failed()
+    restart_info.mark_run_finished(42)
+    restart_info.mark_attempt_failed()
+    restart_info.save()
+
+    # load new instance from the saved file
+    rs2 = RestartInfo(restart_info.file_path)
+    assert restart_info._data == rs2._data

--- a/hp_optim/utils/__init__.py
+++ b/hp_optim/utils/__init__.py
@@ -48,7 +48,7 @@ class RestartInfo:
     def failed_attempts(self) -> int:
         """Get number of failed attempts for the current run."""
         try:
-            return self._data["failed_attempts"][self.finished_runs]
+            return self._data["failed_attempts"][str(self.finished_runs)]
         except KeyError:
             return 0
 
@@ -69,6 +69,6 @@ class RestartInfo:
     def mark_attempt_failed(self):
         """Mark the current attempt as failed."""
         try:
-            self._data["failed_attempts"][self.finished_runs] += 1
+            self._data["failed_attempts"][str(self.finished_runs)] += 1
         except KeyError:
-            self._data["failed_attempts"][self.finished_runs] = 1
+            self._data["failed_attempts"][str(self.finished_runs)] = 1

--- a/hp_optim/utils/__init__.py
+++ b/hp_optim/utils/__init__.py
@@ -1,0 +1,74 @@
+"""Utils for the hyperparameter search with cluster_utils."""
+import json
+import os
+import pathlib
+import typing
+
+
+class RestartInfo:
+    """Provides access to the restart info.
+
+    The "restart info" contains information about the number of already finished
+    training runs as well as failed attempts of the current job.
+    """
+
+    __slots__ = ["file_path", "_data"]
+
+    def __init__(self, file_path: typing.Union[str, os.PathLike]):
+        """
+        Args:
+            file_path: Path to the file in which the restart info is stored.
+        """
+        self.file_path = pathlib.Path(file_path)
+
+        # load
+        if self.file_path.exists():
+            with open(self.file_path, "r") as f:
+                self._data = json.load(f)
+        else:
+            self._data = {"finished_runs": 0, "eprewmean": [], "failed_attempts": {}}
+
+    def save(self):
+        """Save changes to file.
+
+        Call this to save changes on the restart info to the file.
+        """
+        with open(self.file_path, "w") as f:
+            json.dump(self._data, f)
+
+    @property
+    def finished_runs(self) -> int:
+        """Get number of already finished runs.
+
+        This also corresponds to the index of the current run (starting at zero).
+        """
+        return self._data["finished_runs"]
+
+    @property
+    def failed_attempts(self) -> int:
+        """Get number of failed attempts for the current run."""
+        try:
+            return self._data["failed_attempts"][self.finished_runs]
+        except KeyError:
+            return 0
+
+    @property
+    def rewards(self) -> typing.List[float]:
+        """Get list of rewards of all runs."""
+        return self._data["eprewmean"]
+
+    def mark_run_finished(self, eprewmean: float):
+        """Mark the current run as successfully finished and log its reward.
+
+        Args:
+            eprewmean: Reward that was achieved by the run.
+        """
+        self._data["finished_runs"] += 1
+        self._data["eprewmean"].append(eprewmean)
+
+    def mark_attempt_failed(self):
+        """Mark the current attempt as failed."""
+        try:
+            self._data["failed_attempts"][self.finished_runs] += 1
+        except KeyError:
+            self._data["failed_attempts"][self.finished_runs] = 1


### PR DESCRIPTION
## Description

There was an issue with the `RestartInfo` class resulting in some jobs to fail on the cluster.
To be able to debug/test it more easily, I moved it to a "utils" package and added unit tests.

These tests revealed the cause of the issue:  Storing to json and reloading resulted in dictionary keys to get converted from int to str.  This is fixed in the second commit by always using strings for the keys.


## How I Tested

- By running the new unit tests.
- By running the hyperparameter search on the cluster (still running at the moment).

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
