### PR TITLE
updated from selection of robot via bool to selection via robot type …

### DIFF
--- a/bin/hysr_visualization
+++ b/bin/hysr_visualization
@@ -41,6 +41,7 @@ class _Config:
     segment_id_ball = pam_mujoco.segment_ids.ball
     segment_id_hit_point = pam_mujoco.segment_ids.hit_point
     segment_id_goal = pam_mujoco.segment_ids.goal
+    robot_type = None
     nb_extra_balls = 0
     robot_position = None
     robot_orientation = None
@@ -50,6 +51,7 @@ class _Config:
 
 def _get_handle_to(
     mujoco_id,
+    robot_type,
     robot_position,
     robot_orientation,
     table_position,
@@ -79,8 +81,9 @@ def _get_handle_to(
     table = pam_mujoco.MujocoTable(
         segment_id_table, position=table_position, orientation=table_orientation
     )
+
     robot = pam_mujoco.MujocoRobot(
-        pamy1=False,
+        robot_type=robot_type,
         segment_id=segment_id_robot,
         position=robot_position,
         orientation=robot_orientation,
@@ -137,6 +140,7 @@ def _execute_visualization(config):
 
     handle_to = _get_handle_to(
         config.mujoco_id_to,
+        config.robot_type,
         config.robot_position,
         config.robot_orientation,
         config.table_position,
@@ -246,6 +250,7 @@ def execute():
     print("\nusing configuration file:\n- {}\n".format(hysr_path))
     hysr_config = HysrOneBallConfig.from_json(hysr_path)
     config = _Config()
+    config.robot_type = hysr_config.robot_type
     config.robot_position = hysr_config.robot_position
     config.robot_orientation = hysr_config.robot_orientation
     config.table_position = hysr_config.table_position

--- a/config/hysr_demos.json
+++ b/config/hysr_demos.json
@@ -1,5 +1,6 @@
 {
     "real_robot":false,
+    "robot_type":"pamy2",
     "o80_pam_time_step":0.002,
     "mujoco_time_step":0.002,
     "algo_time_step":0.01,

--- a/config/hysr_one_ball_default.json
+++ b/config/hysr_one_ball_default.json
@@ -1,5 +1,6 @@
 {
     "real_robot":false,
+    "robot_type":"pamy2",
     "o80_pam_time_step":0.002,
     "mujoco_time_step":0.002,
     "algo_time_step":0.01,

--- a/config/hysr_one_ball_default_sim.json
+++ b/config/hysr_one_ball_default_sim.json
@@ -1,5 +1,6 @@
 {
     "real_robot": false,
+    "robot_type":"pamy2",
     "o80_pam_time_step":0.002,
     "mujoco_time_step":0.002,
     "algo_time_step":0.01,

--- a/config/hysr_one_ball_real_system.json
+++ b/config/hysr_one_ball_real_system.json
@@ -1,5 +1,6 @@
 {
     "real_robot":"real_robot",
+    "robot_type":"pamy2",
     "o80_pam_time_step":0.002,
     "mujoco_time_step":0.002,
     "algo_time_step":0.01,

--- a/learning_table_tennis_from_scratch/configure_mujoco.py
+++ b/learning_table_tennis_from_scratch/configure_mujoco.py
@@ -48,7 +48,7 @@ def configure_extra_set(setid, hysr_config):
 
     robot_segment_id = get_extra_robot_segment_id(setid)
     robot = pam_mujoco.MujocoRobot(
-        pamy1=False,
+        robot_type=hysr_config.robot_type,
         segment_id=robot_segment_id,
         position=hysr_config.robot_position,
         orientation=hysr_config.robot_orientation,
@@ -84,7 +84,7 @@ def configure_extra_set(setid, hysr_config):
 
 
 def configure_pseudo_real(
-    pam_config_file, mujoco_id="pseudo-real", graphics=True, accelerated_time=False
+        pam_config_file, robot_type, mujoco_id="pseudo-real", graphics=True, accelerated_time=False
 ):
 
     if accelerated_time:
@@ -93,7 +93,7 @@ def configure_pseudo_real(
         burst_mode = False
 
     robot = pam_mujoco.MujocoRobot(
-        pamy1=False,
+        robot_type=robot_type,
         segment_id=SEGMENT_ID_PSEUDO_REAL_ROBOT,
         control=pam_mujoco.MujocoRobot.PRESSURE_CONTROL,
         json_control_path=pam_config_file,
@@ -123,7 +123,7 @@ def configure_simulation(hysr_config, mujoco_id="simulation"):
         orientation=hysr_config.table_orientation,
     )
     robot = pam_mujoco.MujocoRobot(
-        pamy1=False,
+        robot_type=hysr_config.robot_type,
         segment_id=SEGMENT_ID_ROBOT_MIRROR,
         position=hysr_config.robot_position,
         orientation=hysr_config.robot_orientation,

--- a/learning_table_tennis_from_scratch/hysr_one_ball.py
+++ b/learning_table_tennis_from_scratch/hysr_one_ball.py
@@ -26,10 +26,23 @@ SEGMENT_ID_EPISODE_FREQUENCY = "hysr_episode_frequency"
 SEGMENT_ID_STEP_FREQUENCY = "hysr_step_frequency"
 
 
+
+def _to_robot_type(robot_type:str)->pam_mujoco.RobotType:
+    if robot_type=="pamy1":
+        return pam_mujoco.RobotType.PAMY1
+    elif robot_type=="pamy2":
+        return pam_mujoco.RobotType.PAMY2
+    else:
+        error = str("hysr configuration robot_type should be either "
+                    "'pamy1' or 'pamy2' (entered value: {})").format(robot_type)
+        raise ValueError(error)
+
+
 class HysrOneBallConfig:
 
     __slots__ = (
         "real_robot",
+        "robot_type",
         "o80_pam_time_step",
         "mujoco_time_step",
         "algo_time_step",
@@ -62,7 +75,7 @@ class HysrOneBallConfig:
     def __init__(self):
         for s in self.__slots__:
             setattr(self, s, None)
-
+            
     def get(self):
         r = {s: getattr(self, s) for s in self.__slots__}
         return r
@@ -90,6 +103,9 @@ class HysrOneBallConfig:
                 raise ValueError(
                     "failed to find the attribute {} " "in {}".format(s, jsonpath)
                 )
+        # robot type given as string in json config, but
+        # the rest of the code will expect a pam_mujoco.RobotType
+        instance.robot_type = _to_robot_type(instance.robot_type)
         return instance
 
     @staticmethod
@@ -300,6 +316,7 @@ class HysrOneBall:
                 self._real_robot_frontend,
             ) = configure_mujoco.configure_pseudo_real(
                 hysr_config.pam_config_file,
+                hysr_config.robot_type,
                 graphics=hysr_config.graphics_pseudo_real,
                 accelerated_time=hysr_config.accelerated_time,
             )

--- a/learning_table_tennis_from_scratch/hysr_one_ball.py
+++ b/learning_table_tennis_from_scratch/hysr_one_ball.py
@@ -28,11 +28,9 @@ SEGMENT_ID_STEP_FREQUENCY = "hysr_step_frequency"
 
 
 def _to_robot_type(robot_type:str)->pam_mujoco.RobotType:
-    if robot_type=="pamy1":
-        return pam_mujoco.RobotType.PAMY1
-    elif robot_type=="pamy2":
-        return pam_mujoco.RobotType.PAMY2
-    else:
+    try :
+        return pam_mujoco.RobotType[robot_type.upper()]
+    except KeyError:
         error = str("hysr configuration robot_type should be either "
                     "'pamy1' or 'pamy2' (entered value: {})").format(robot_type)
         raise ValueError(error)


### PR DESCRIPTION
…(pam_mujoco pull request 31)

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Using RobotType to select pamy1 or pamy2, following update of pam_mujoco (pull request 31)

## How I Tested

Ran executables

## Do not merge before

https://github.com/intelligent-soft-robots/pam_mujoco/pull/31

## I fulfilled the following requirements

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
