### PR TITLE
Run hyperparameter search for values of vector

### DIFF
--- a/config/rl_common_default.json
+++ b/config/rl_common_default.json
@@ -1,5 +1,5 @@
 {
-    "algorithm": "sac",
+    "algorithm": "ppo",
     "use_openai_baselines": false,
     "log_episodes": false,
     "random_seed": null

--- a/hp_optim/README.md
+++ b/hp_optim/README.md
@@ -129,6 +129,24 @@ for "rl_config" in the template file (see above), the name would be
     config.rl_config.num_hidden
 
 
+#### Non-scalar parameters
+
+`cluster_utils` can only handle scalar values.  For parameters that expect a list of
+values, run_learning.py has some special handling.  For this add ``:<index>`` at the end
+of the parameter name.  Example:
+
+    "optimized_params": [
+        {
+            "param": "config.hysr_config.robot_position:0",
+            "distribution": "TruncatedNormal",
+            "bounds": [-0.35, 0.35]
+        }
+    ]
+
+This will sample a value for index 0 of parameter ``robot_position`` in the hysr
+configuration.
+
+
 ### Configuring number of reruns and retries
 
 Independent of the `with_restarts` option of cluster utils, the

--- a/hp_optim/hp_optim_ppo.json
+++ b/hp_optim/hp_optim_ppo.json
@@ -1,5 +1,5 @@
 {
-    "optimization_procedure_name": "hyper_param_optim_lttfs_ppo_100_10",
+    "optimization_procedure_name": "lttfs_robot_position",
     "results_dir": "/home/felixwidmaier/tmp",
     "run_in_working_dir": false,
     "git_params": {
@@ -15,8 +15,8 @@
         "request_cpus": 2,
         "request_gpus": 0,
         "cuda_requirement": null,
-        "memory_in_mb": 10000,
-        "bid": 10
+        "memory_in_mb": 15000,
+        "bid": 100
     },
     "fixed_params": {
         "learning_runs_per_job": 3,
@@ -39,25 +39,14 @@
     "num_best_jobs_whose_data_is_kept": 10,
     "optimized_params": [
         {
-            "param": "config.rl_config.num_layers",
-            "distribution": "Discrete",
-            "options": [1, 2]
+            "param": "config.hysr_config.robot_position:0",
+            "distribution": "TruncatedNormal",
+            "bounds": [-0.35, 0.35]
         },
         {
-            "param": "config.rl_config.num_hidden",
-            "distribution": "IntLogNormal",
-            "bounds": [32, 8192]
-        },
-        {
-            "param": "config.rl_config.learning_rate",
-            "distribution": "TruncatedLogNormal",
-            "bounds": [1e-5, 1e-1]
-        },
-        {
-            "param": "config.hysr_config.pressure_change_range",
-            "distribution": "IntLogNormal",
-            "bounds": [180, 18000]
+            "param": "config.hysr_config.robot_position:1",
+            "distribution": "TruncatedNormal",
+            "bounds": [-0.35, 0.35]
         }
-
     ]
 }

--- a/hp_optim/run_learning.py
+++ b/hp_optim/run_learning.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import subprocess
 import sys
 import time
@@ -94,8 +95,11 @@ def prepare_config_file(
     """Create config file based on the given template and parameter updates.
 
     The given template is expected to be a valid config file in JSON format.
-    The *paramter_updates* dict can be used to overwrite some of the default
+    The *parameter_updates* dict can be used to overwrite some of the default
     values with custom ones.
+
+    If a parameter name is suffixed with ``:#`` (where # is a number), it will assume
+    that the value of this parameter is a list and will overwrite the value at index #.
 
     The resulting config will be written to "destination_directory/name.json".
 
@@ -107,11 +111,28 @@ def prepare_config_file(
         destination_directory:  Directory to which the resulting configuration
             file is written.
     """
+    logger = get_logger()
+
     with open(template_file, "r") as f:
         config = json.load(f)
 
+    list_parameters = []
+
     # check if all provided parameter updates correspond to existing parameters
     for param in parameter_updates:
+
+        # if parameter name ends with ":#", this indicates the #-th index of a parameter
+        # whose value is a list
+        m = re.match(r"(.*):([0-9])+$", param)
+        if m is not None:
+            param_name = m.group(1)
+            index = int(m.group(2))
+            logger.info("Process list parameter %s[%d]" % (param_name, index))
+            list_parameters.append((param_name, index, parameter_updates[param]))
+
+            # overwrite for following check
+            param = param_name
+
         if param not in config:
             raise KeyError(
                 (
@@ -121,6 +142,17 @@ def prepare_config_file(
             )
 
     config.update(parameter_updates)
+
+    for param, index, value in list_parameters:
+        try:
+            config[param][index] = value
+        except IndexError:
+            raise IndexError(
+                (
+                    "Provided update for parameter '{param}[{index}]' in {config_name}"
+                    " [{file}], but index is out of bounds."
+                ).format(config_name=name, file=template_file, param=param, index=index)
+            )
 
     destination_file = destination_directory / "{}.json".format(name)
     with open(destination_file, "w") as f:

--- a/hp_optim/run_learning.py
+++ b/hp_optim/run_learning.py
@@ -181,7 +181,7 @@ def setup_config(working_dir: pathlib.Path, params: dict) -> pathlib.Path:
             "reward_config": "./config/reward_config.json",
             "hysr_config": "./config/hysr_config.json",
             "pam_config": "./config/pam_config.json",
-            "rl_config": "./config/ppo_config.json",
+            "rl_config": "./config/rl_config.json",
             "rl_common_config": "./config/rl_common_config.json",
         }
         with open(main_config_file, "w") as f:


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

`cluster_utils` only works with scalar parameters, so it is not possible to directly optimise over vector-parameters (like `robot_position`).  As a simple workaround, add some hack to `run_learning.py`:  If the parameter name ends with `:#`, it will assume that this parameter is indexable and set the value at index `#`.  Example:

    "optimized_params": [
        {
            "param": "config.hysr_config.robot_position:0",
            "distribution": "TruncatedNormal",
            "bounds": [-0.35, 0.35]
        }
    ]

Also update the configuration for optimising the robot position.


## How I Tested

Currently running hyperparameter search on the cluster with this branch.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
