### PR TITLE
fix: Set seed for stable_baselines

### DIFF
--- a/bin/hysr_one_ball_rl
+++ b/bin/hysr_one_ball_rl
@@ -4,7 +4,6 @@ import argparse
 import json
 import os
 import pathlib
-import random
 import time
 
 from learning_table_tennis_from_scratch.models import run_stable_baselines
@@ -55,7 +54,6 @@ def _execute(
         seed = int((time.time() % 1) * 1e9)
     print("Use random seed %d" % seed)
 
-    random.seed(seed)
     if common_conf["use_openai_baselines"]:
         run_openai_baselines(
             reward_config_file,
@@ -71,6 +69,7 @@ def _execute(
             rl_config_file,
             common_conf["algorithm"],
             common_conf["log_episodes"],
+            seed=seed,
         )
 
 

--- a/learning_table_tennis_from_scratch/models.py
+++ b/learning_table_tennis_from_scratch/models.py
@@ -17,7 +17,11 @@ def run_stable_baselines(
     from stable_baselines3 import SAC
     from stable_baselines3.common import logger
     from stable_baselines3.common.env_util import make_vec_env
+    from stable_baselines3.common.utils import set_random_seed
     from stable_baselines3.common.callbacks import CheckpointCallback
+
+    if seed is not None:
+        set_random_seed(seed)
 
     rl_config = RLConfig.from_json(rl_config_file, algorithm)
 
@@ -29,7 +33,8 @@ def run_stable_baselines(
         )
         tensorboard_logger.set_level(logger.INFO)
 
-        # Save a checkpoint every n_steps steps, or every 10000 steps if n_steps does not exist (e.g. SAC)
+        # Save a checkpoint every n_steps steps, or every 10000 steps if n_steps does
+        # not exist (e.g. SAC)
         save_freq = getattr(rl_config, "n_steps", 10000)
 
         checkpoint_callback = CheckpointCallback(
@@ -43,7 +48,7 @@ def run_stable_baselines(
         "log_episodes": log_episodes,
         "logger": tensorboard_logger,
     }
-    env = make_vec_env(HysrOneBallEnv, env_kwargs=env_config)
+    env = make_vec_env(HysrOneBallEnv, env_kwargs=env_config, seed=seed)
 
     model_type = {"ppo": PPO, "sac": SAC}
 


### PR DESCRIPTION
## Description

Most relevant part is that the seed was not passed to `run_stable_baselines()` before.
Remove redundant call of `random.seed()` (this is already done internally in both openai baselines and stable_baselines).


To be on the save side, also explicitly call `set_random_seed` and pass
it to `make_vec_env` (not sure if these are really necessary, but it
doesn't harm).



## How I Tested

By running the learning (with very low number of timesteps to save time) and comparing the resulting episode rewards in the logs.
Note that accelerated_time needs to be enabled to be fully repeatable.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
