### PR TITLE
Add option to load model to continue training

### DIFF
--- a/config/ppo_default.json
+++ b/config/ppo_default.json
@@ -12,6 +12,7 @@
     "clip_range_vf": 0.3,
     "log_path": "/tmp/training_log",
     "num_timesteps": 500000,
+    "load_path": "",
     "save_path": "/tmp/model",
     "num_layers": 1,
     "num_hidden": 380

--- a/config/sac_default.json
+++ b/config/sac_default.json
@@ -5,6 +5,7 @@
     "batch_size": 90,
     "log_path": "/tmp/training_log",
     "num_timesteps": 500000,
+    "load_path": "",
     "save_path": "/tmp/model",
     "num_layers": 1,
     "num_hidden": 60,

--- a/learning_table_tennis_from_scratch/rl_config.py
+++ b/learning_table_tennis_from_scratch/rl_config.py
@@ -40,6 +40,7 @@ class RLConfig:
     # Additional parameters
     _additional_params = (
         "num_timesteps",  # 'total_timesteps' passed to RL.learn()
+        "load_path",  # If set the model is saved to the given path.
         "save_path",  # If set the model is saved to the given path.
         "num_layers",  # Number of layers in the network
         "num_hidden",  # Size of each layer (all layers have same size)


### PR DESCRIPTION
## Description

Add parameter `load_model` to rl_config files.  If set to a non-empty value, it is interpreted as a path to a model file, which get's loaded to continue training (instead of starting training from scratch).

I did this already some time ago when debugging the issue that loading models didn't work as expected.  With this implementation (making sure that `reset_num_timesteps` is set correctly) it was working correctly for me, so it would probably make sense to merge this.


## How I Tested

Tested intensively back then when debugging the issue.  Now I just removed some debugging code and quickly made sure that it still runs without error.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
