### PR TITLE
Use variconf for HysrOneBallConfig 

### DIFF
--- a/config/hysr_demos.json
+++ b/config/hysr_demos.json
@@ -1,6 +1,6 @@
 {
     "real_robot":false,
-    "robot_type":"pamy2",
+    "robot_type":"PAMY2",
     "o80_pam_time_step":0.002,
     "mujoco_time_step":0.002,
     "algo_time_step":0.01,

--- a/config/hysr_one_ball_default.json
+++ b/config/hysr_one_ball_default.json
@@ -1,6 +1,6 @@
 {
     "real_robot":false,
-    "robot_type":"pamy2",
+    "robot_type":"PAMY2",
     "o80_pam_time_step":0.002,
     "mujoco_time_step":0.002,
     "algo_time_step":0.01,

--- a/config/hysr_one_ball_default_sim.json
+++ b/config/hysr_one_ball_default_sim.json
@@ -1,6 +1,6 @@
 {
     "real_robot": false,
-    "robot_type":"pamy2",
+    "robot_type":"PAMY2",
     "o80_pam_time_step":0.002,
     "mujoco_time_step":0.002,
     "algo_time_step":0.01,

--- a/config/hysr_one_ball_real_system.json
+++ b/config/hysr_one_ball_real_system.json
@@ -1,6 +1,6 @@
 {
     "real_robot":"real_robot",
-    "robot_type":"pamy2",
+    "robot_type":"PAMY2",
     "o80_pam_time_step":0.002,
     "mujoco_time_step":0.002,
     "algo_time_step":0.01,

--- a/learning_table_tennis_from_scratch/hysr_one_ball_env.py
+++ b/learning_table_tennis_from_scratch/hysr_one_ball_env.py
@@ -111,8 +111,8 @@ class HysrOneBallEnv(gym.Env):
 
         self._obs_boxes.add_box(
             "ball_position",
-            min(hysr_one_ball_config.world_boundaries["min"]),
-            max(hysr_one_ball_config.world_boundaries["max"]),
+            min(hysr_one_ball_config.world_boundaries.min),
+            max(hysr_one_ball_config.world_boundaries.max),
             3,
         )
         self._obs_boxes.add_box("ball_velocity", -10.0, +10.0, 3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ extend-exclude = "runner_buffered\\.py|modified_baselines_ppo2\\.py"
 module = [
     "context",
     "frequency_monitoring",
+    "gym",
     "o80",
     "o80_pam",
     "pam_interface",


### PR DESCRIPTION
## Description

Use [variconf](https://github.com/MPI-IS/variconf) with a dataclass schema for HysrOneBallConfig.
This allows us to specify types (which are automatically checked) and
default values for parameters.

A few notes:

- Since the type checking capabilities are a bit limited, some fields
  are set to "Any".
- The "robot_type" field is now cases-sensitive, values need to match
  the enum names (i.e. upper case).

I inferred the types from the config file but it would be create if you could double-check them.

## How I Tested

By running `hysr_start_robots` with the example config.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
