### PR TITLE
Fix one-step delay in the ball replay

### DIFF
--- a/learning_table_tennis_from_scratch/hysr_one_ball.py
+++ b/learning_table_tennis_from_scratch/hysr_one_ball.py
@@ -662,8 +662,7 @@ class HysrOneBall:
         trajectory = self._ball_behavior.get_trajectory()
         iterator = context.ball_trajectories.BallTrajectories.iterate(trajectory)
         # setting the ball to the first trajectory point
-        duration, state = next(iterator)
-        self._ball_communication.set(state.get_position(), [0, 0, 0])
+        self._ball_communication.set(trajectory[1][0], [0, 0, 0])
         # shooting the ball
         self._ball_communication.iterate_trajectory(iterator, overwrite=False)
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
This fixes a one-step delay in the ball replay (the first step of the iterator was removed before it was passed to `o80Ball.iterate_trajectory()`).

Before:
![ball_trajectory_before](https://github.com/user-attachments/assets/2335871f-071c-4a93-93d9-9075efe8e476)

After:
![ball_trajectory_after](https://github.com/user-attachments/assets/12feab37-a915-4f9d-a632-9526609a1842)


[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."


## How I Tested

[//]: # "Explain how you tested your changes"


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [ ] link to dependent pull request

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
