### PR TITLE
Added a config argument to hysr_visualization

### DIFF
--- a/bin/hysr_visualization
+++ b/bin/hysr_visualization
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+import argparse
 import logging
+import pathlib
 
 import signal_handler
 import o80
@@ -252,7 +254,18 @@ def execute():
         level=logging.INFO,
     )
 
-    files = get_json_config(expected_keys=["hysr_config"])
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "config",
+        type=pathlib.Path,
+        nargs="?",  # this is optional
+        help="""Optional path to config JSON file.  If not set, the file is
+            searched for in the current working directory.
+        """,
+    )
+    args = parser.parse_args()
+
+    files = get_json_config(expected_keys=["hysr_config"], config_file=args.config)
     hysr_path = files["hysr_config"]
     logging.info("\nUsing configuration file:\n- %s\n", hysr_path)
     hysr_config = HysrOneBallConfig.from_json(hysr_path)


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

This adds the option to pass a config file as input to `hysr_visualization`, which is needed if there are multiple json files in the current directory (e.g., different configs for training and evaluation).

## How I Tested

[//]: # "Explain how you tested your changes"

Ran `hysr_visualization` and `hysr_visualization config.json`.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
