### PR TITLE
Fix target postion in default config

### DIFF
--- a/config/hysr_demos.json
+++ b/config/hysr_demos.json
@@ -13,7 +13,7 @@
     "table_position":[0.4, 1.57, 0.755],
     "table_orientation": [0, 0, 0, 1],
     "starting_pressures":[[18000,18000],[18000,18000],[18000,18000],[18000,18000]],
-    "target_position":[0.0,2.5,1.78],
+    "target_position":[0.4,2.5,0.78],
     "reference_posture":[[19900,16000],[16800,19100],[18700,17300],[18000,18000]],
     "world_boundaries":{
         "min":[0.0,-1.0,0.17],

--- a/learning_table_tennis_from_scratch/hysr_one_ball.py
+++ b/learning_table_tennis_from_scratch/hysr_one_ball.py
@@ -936,11 +936,11 @@ class HysrOneBall:
         # otherwise exiting based on a threshold on the
         # z position of the ball
 
-        # ball falled below the table
+        # ball fell below the table
         # note : all prerecorded trajectories are added a last ball position
         # with z = -10.0, to insure this always occurs.
         # see: function reset
-        if self._ball_status.ball_position[2] < 0.8:
+        if self._ball_status.ball_position[2] < self._hysr_config.target_position[2]:
             return True
         # in case the user called the method
         # force_episode_over


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

At the moment, the target position in the default config is hovering 1m above the table, and it is close to the edge in the x-direction.
<img src="https://github.com/user-attachments/assets/a1e0bbb3-9e34-4f1f-a402-223337940af4" width="250">

This PR moves the target position down and to the center of the table. 

<img src="https://github.com/user-attachments/assets/8b07d716-4ad9-4474-8305-386bf951537d" width="250">


Furthermore, I removed the hardcoded table height in `hysr_one_ball.py` to avoid problems if the table height is changed in the config.

## How I Tested

[//]: # "Explain how you tested your changes"

The learning performance looks good. With the old config (magenta) the agent cannot reach the goal properly and gets low rewards. With the updated config (blue), the rewards are much better.

![Screenshot from 2024-10-11 12-03-10](https://github.com/user-attachments/assets/233823c3-8e20-45a4-a91c-706e750c6f4a)

