### PR TITLE
Adding the algorithm step in shared memory

### DIFF
--- a/learning_table_tennis_from_scratch/hysr_one_ball.py
+++ b/learning_table_tennis_from_scratch/hysr_one_ball.py
@@ -845,7 +845,8 @@ class HysrOneBall:
 
     def reset(self):
         # what happens during reset does not correspond
-        # to any episode (-1 means: no active episode)
+        # to any step/episode (-1 means: no active step/episode)
+        self._share_step_number(-1)
         self._share_episode_number(-1)
 
         # resetting the measure of step frequency monitoring

--- a/learning_table_tennis_from_scratch/hysr_one_ball.py
+++ b/learning_table_tennis_from_scratch/hysr_one_ball.py
@@ -596,6 +596,12 @@ class HysrOneBall:
         for mujoco_id in self._mujoco_ids:
             shared_memory.set_long_int(mujoco_id, "episode", episode_number)
 
+    def _share_step_number(self, step_number):
+        # write the step number in a memory shared
+        # with the instances of mujoco
+        for mujoco_id in self._mujoco_ids:
+            shared_memory.set_long_int(mujoco_id, "step", step_number)
+
     def force_episode_over(self):
         # will trigger the method _episode_over
         # (called in the step method) to return True
@@ -918,6 +924,7 @@ class HysrOneBall:
 
         # a new episode starts
         self._step_number = 0
+        self._share_step_number(self._step_number)
         self._episode_number += 1
         self._share_episode_number(self._episode_number)
 
@@ -1062,6 +1069,7 @@ class HysrOneBall:
 
         # this step is done
         self._step_number += 1
+        self._share_step_number(self._step_number)
 
         # returning
         return observation, reward, episode_over


### PR DESCRIPTION
This PR adds the current step of the RL agent, i.e., the step in the current episode, to the shared memory. This is required to remove a hack in the contact model in pam_mujoco.
